### PR TITLE
Case sensitive filename in index.js

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -52,7 +52,7 @@ var FluxWebappGenerator = yeoman.generators.Base.extend({
       this.template('src/pages/404.html');
       this.template('src/pages/_template.html', 'src/pages/_template.html', context);
       this.src.copy('src/actions/RouteActions.js', 'src/actions/RouteActions.js');
-      this.src.copy('src/pages/index.jsx', 'src/pages/index.jsx');
+      this.src.copy('src/pages/Index.jsx', 'src/pages/Index.jsx');
       this.src.copy('src/pages/Privacy.jsx', 'src/pages/Privacy.jsx');
       this.directory('src/assets/', 'src/assets/');
       this.directory('src/components/', 'src/components/');


### PR DESCRIPTION
When i run your generator in a unix environment (cloud9), i get this exception:

```
? Your project name: testApp

fs.js:689
  return binding.stat(pathModule._makeLong(path));
                 ^
Error: ENOENT, no such file or directory '/home/ubuntu/.nvm/v0.10.30/lib/node_modules/generator-flux-webapp/app/templates/src/pages/index.jsx'
    at Object.fs.statSync (fs.js:689:18)
    at Env.File.copy (/home/ubuntu/.nvm/v0.10.30/lib/node_modules/generator-flux-webapp/node_modules/yeoman-generator/node_modules/file-utils/lib/file.js:305:14)
    at Env.copy (/home/ubuntu/.nvm/v0.10.30/lib/node_modules/generator-flux-webapp/node_modules/yeoman-generator/node_modules/file-utils/lib/env.js:32:32)
    at yeoman.generators.Base.extend.writing.app (/home/ubuntu/.nvm/v0.10.30/lib/node_modules/generator-flux-webapp/app/index.js:55:16)
    at /home/ubuntu/.nvm/v0.10.30/lib/node_modules/generator-flux-webapp/node_modules/yeoman-generator/lib/base.js:395:14
    at processImmediate [as _immediateCallback] (timers.js:345:15)
```

After changing this line, i was able to start this generator inside cloud9. 
